### PR TITLE
FIX: incomplete network data libnetwork/network.go

### DIFF
--- a/components/engine/vendor/github.com/docker/libnetwork/network.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/network.go
@@ -1172,6 +1172,13 @@ func (n *network) createEndpoint(name string, options ...EndpointOption) (Endpoi
 	if err = n.addEndpoint(ep); err != nil {
 		return nil, err
 	}
+	
+	// We should update store after network driver response
+	// in order to save full data. 
+	if err = n.getController().updateToStore(ep); err != nil {
+		return nil, err
+	}
+	
 	defer func() {
 		if err != nil {
 			if e := ep.deleteEndpoint(false); e != nil {


### PR DESCRIPTION
Data from network plugin response are going to be lost, because driver response are not written to KV storage. 
Need to update KV after driver response.

Please do not send pull requests to this docker/docker-ce repository.

We do, however, take contributions gladly.

See https://github.com/docker/docker-ce/blob/master/CONTRIBUTING.md

Thanks!
